### PR TITLE
Testing reuse of the ollama cache

### DIFF
--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -84,7 +84,9 @@ def in_existing_cache(model_name, model_tag):
 
 class Ollama(Model):
     def __init__(self, model):
-        super().__init__(model.removeprefix("ollama://"))
+        model = rm_until_substring(model, "ollama.com/library/")
+        model = rm_until_substring(model, "://")
+        super().__init__(model)
         self.type = "Ollama"
 
     def _local(self, args):


### PR DESCRIPTION
Checks if the model layer already exists in some local Ollama cache before downloading the whole file.

If it exists, symbolic symlink to where it would have been downloaded. This way we can get ls and rm working while not affecting the source (Ollama) cache.