### PR TITLE
Add test function to check hf-cli and tests for pulling from hf cache

### DIFF
--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -71,6 +71,8 @@ load setup_suite
     run_ramalama list
     is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
     run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    rm -rf ~/.cache/huggingface/hub/models--Felladrin--gguf-smollm-360M-instruct-add-basics
 }
 
 # bats test_tags=distro-integration

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -53,6 +53,27 @@ load setup_suite
 }
 
 # bats test_tags=distro-integration
+@test "ramalama pull huggingface-cli cache" {
+    skip_if_no_hf-cli
+    huggingface-cli download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+    run_ramalama list
+    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
+    run_ramalama rm hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    run_ramalama pull huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+    run_ramalama list
+    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
+    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    RAMALAMA_TRANSPORT=huggingface run_ramalama pull Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+    run_ramalama list
+    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
+    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+}
+
+# bats test_tags=distro-integration
 @test "ramalama pull oci" {
     skip "Waiting for podman artiface support" 
     run_ramalama pull oci://quay.io/mmortari/gguf-py-example:v1

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -270,5 +270,12 @@ function skip_if_darwin() {
     fi
 }
 
+function skip_if_no_hf-cli(){
+    if ! command -v huggingface-cli 2>&1 >/dev/null
+    then
+        skip "Not supported without huggingface-cli"
+    fi
+}
+
 # END   miscellaneous tools
 ###############################################################################


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Adds a system test to verify that `ramalama pull` can pull images from the Hugging Face cache when using `hf://`, `huggingface://`, or setting `RAMALAMA_TRANSPORT=huggingface`.