### PR TITLE
Add tests and improvements for Ollama cache pulls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
            sudo apt-get install podman bats bash codespell python3-argcomplete pipx
            make install-requirements
 
+      - name: install ollama
+        shell: bash
+        run: |
+           curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz
+           sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+           sudo useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+           sudo usermod -a -G ollama runner
+
       - name: Upgrade to podman 5
         run: |
            set -e
@@ -85,6 +93,14 @@ jobs:
            make install-requirements
            sudo ./container-images/scripts/build_llama_and_whisper.sh
 
+      - name: install ollama
+        shell: bash
+        run: |
+           curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz
+           sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+           sudo useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+           sudo usermod -a -G ollama runner
+
       - name: Upgrade to podman 5
         run: |
            set -e
@@ -110,6 +126,14 @@ jobs:
            sudo apt-get update
            sudo apt-get install bats bash codespell python3-argcomplete pipx
            make install-requirements
+
+      - name: install ollama
+        shell: bash
+        run: |
+           curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz
+           sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+           sudo useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+           sudo usermod -a -G ollama runner
 
       - name: Upgrade to podman 5
         run: |
@@ -158,6 +182,13 @@ jobs:
         run: |
            brew install go bats bash jq llama.cpp shellcheck
            make install-requirements
+
+      - name: install ollama
+        shell: bash
+        run: |
+           brew install ollama
+           brew services start ollama
+
       - name: Run a one-line script
         shell: bash
         run: |

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -68,12 +68,12 @@ def in_existing_cache(model_name, model_tag):
     default_ollama_caches = [
         os.path.join(os.environ['HOME'], '.ollama/models'),
         '/usr/share/ollama/.ollama/models',
-        f'C:\\Users\\{os.getlogin()}\\.ollama\\models',
+        f'C:\\Users\\%username%\\.ollama\\models',
     ]
 
     for cache_dir in default_ollama_caches:
         manifest_path = os.path.join(cache_dir, 'manifests', 'registry.ollama.ai', model_name, model_tag)
-        if os.path.exists(manifest_path):
+        if os.path.exists(manifest_path) and os.access(manifest_path, os.R_OK):
             with open(manifest_path, 'r') as file:
                 manifest_data = json.load(file)
                 for layer in manifest_data["layers"]:

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -68,7 +68,7 @@ def in_existing_cache(model_name, model_tag):
     default_ollama_caches = [
         os.path.join(os.environ['HOME'], '.ollama/models'),
         '/usr/share/ollama/.ollama/models',
-        f'C:\\Users\\%username%\\.ollama\\models',
+        'C:\\Users\\%username%\\.ollama\\models',
     ]
 
     for cache_dir in default_ollama_caches:

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -30,6 +30,37 @@ load setup_suite
 }
 
 # bats test_tags=distro-integration
+@test "ramalama pull ollama cache" {
+    skip_if_no_ollama
+
+    ollama serve &
+    sleep 3
+    ollama pull tinyllama
+    run_ramalama pull tiny
+    run_ramalama rm tiny
+    ollama rm tinyllama
+
+    ollama pull smollm:135m
+    run_ramalama pull https://ollama.com/library/smollm:135m
+    run_ramalama list
+    is "$output" ".*ollama://smollm:135m" "image was actually pulled locally from ollama cache"
+
+    ollama pull smollm:360m
+    RAMALAMA_TRANSPORT=ollama run_ramalama pull smollm:360m
+    run_ramalama pull ollama://smollm:360m
+    run_ramalama list
+    is "$output" ".*ollama://smollm:360m" "image was actually pulled locally from ollama cache"
+    run_ramalama rm ollama://smollm:135m ollama://smollm:360m
+    ollama rm smollm:135m smollm:360m
+
+    random_image_name=i_$(safename)
+    run_ramalama 1 pull ${random_image_name}
+    is "$output" "Error: ${random_image_name} was not found in the Ollama registry"
+
+    pkill ollama
+}
+
+# bats test_tags=distro-integration
 @test "ramalama pull huggingface" {
     run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
     run_ramalama list

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -281,5 +281,12 @@ function skip_if_no_hf-cli(){
     fi
 }
 
+function skip_if_no_ollama() {
+    if ! command -v ollama 2>&1 >/dev/null
+    then
+        skip "Not supported without ollama"
+    fi
+}
+
 # END   miscellaneous tools
 ###############################################################################


### PR DESCRIPTION
Add tests and improvements for Ollama cache pulls

## Summary by Sourcery

This pull request adds support for pulling images from the Ollama cache, enabling ramalama to utilize locally cached Ollama models. It also includes improvements to the logic for detecting existing Ollama caches and adds a system test to verify the new functionality. The CI environment is updated to include Ollama.

New Features:
- Adds support for pulling images from the Ollama cache, allowing ramalama to utilize locally cached Ollama models.

Enhancements:
- Improves the logic for detecting existing Ollama caches by checking if the manifest file is readable.
- Adds support for the %username% environment variable in Windows paths.

CI:
- Installs Ollama in the CI environment to enable testing of Ollama cache pulls.

Tests:
- Adds a system test to verify that ramalama can pull images from the Ollama cache.