### PR TITLE
Detect and warn if Safetensor models or multiple GGUF files are within the HF repo

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -449,8 +449,16 @@ def human_readable_size(size):
     return f"{size} PB"
 
 
-def get_size(file):
-    return os.path.getsize(file)
+def get_size(path):
+    if os.path.isdir(path):
+        size = 0
+        for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
+            for file in filenames:
+                filepath = os.path.join(dirpath, file)
+                if not os.path.islink(filepath):
+                    size += os.path.getsize(filepath)
+        return size
+    return os.path.getsize(path)
 
 
 def _list_models(args):

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -34,7 +34,8 @@ def fetch_checksum_from_api(url):
 
 
 def get_repo_info(repo_name):
-    # Docs on API call here: https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
+    # Docs on API call here: 
+    # https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
     repo_info_url = f"https://huggingface.co/api/models/{repo_name}"
     with urllib.request.urlopen(repo_info_url) as response:
         if response.getcode() == 200:
@@ -85,7 +86,10 @@ class Huggingface(Model):
                 if "safetensors" in repo_info:
                     if args.runtime == "llama.cpp":
                         print(
-                            "\nllama.cpp does not support running safetensor models, please use a/convert to the GGUF format using:\n- https://huggingface.co/spaces/ggml-org/gguf-my-repo \n"
+                            "\n \
+                            llama.cpp does not support running safetensor models, \
+                            please use a/convert to the GGUF format using:\n \
+                            - https://huggingface.co/spaces/ggml-org/gguf-my-repo \n"
                         )
                 if "gguf" in repo_info:
                     print(

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -55,7 +55,7 @@ def handle_repo_info(repo_name, repo_info, runtime):
             "- https://huggingface.co/spaces/ggml-org/gguf-my-repo"
         )
     if "gguf" in repo_info:
-        print("There are GGUF files to choose from in this repo, run one of the following commands to choose one:\n")
+        print("There are GGUF files to choose from in this repo, run one of the following commands to choose one:")
     for sibling in repo_info["siblings"]:
         if sibling["rfilename"].endswith('.gguf'):
             file = sibling["rfilename"]

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -83,17 +83,17 @@ class Huggingface(Model):
             if self.directory.count("/") == 0:
                 repo_name = self.directory + "/" + self.filename
                 repo_info = get_repo_info(repo_name)
-                if "safetensors" in repo_info:
-                    if args.runtime == "llama.cpp":
-                        print(
-                            "\n \
-                            llama.cpp does not support running safetensor models, \
+                if "safetensors" in repo_info and args.runtime == "llama.cpp":
+                    print(
+                        "\n \
+                        llama.cpp does not support running safetensor models, \
                             please use a/convert to the GGUF format using:\n \
-                            - https://huggingface.co/spaces/ggml-org/gguf-my-repo \n"
-                        )
+                                - https://huggingface.co/spaces/ggml-org/gguf-my-repo \n"
+                    )
                 if "gguf" in repo_info:
                     print(
-                        "There are GGUF files to choose in this repo, run one of the following commands to choose one:"
+                        "There are GGUF files to choose in this repo, \
+                            run one of the following commands to choose one:"
                     )
                     for sibling in repo_info["siblings"]:
                         if sibling["rfilename"].endswith('.gguf'):

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -47,6 +47,22 @@ def get_repo_info(repo_name):
     return None
 
 
+def handle_repo_info(repo_name, repo_info, runtime):
+    if "safetensors" in repo_info and runtime == "llama.cpp":
+        print(
+            "\nllama.cpp does not support running safetensor models, "
+            "please use a/convert to the GGUF format using:\n"
+            "- https://huggingface.co/spaces/ggml-org/gguf-my-repo"
+        )
+    if "gguf" in repo_info:
+        print("There are GGUF files to choose from in this repo, run one of the following commands to choose one:\n")
+    for sibling in repo_info["siblings"]:
+        if sibling["rfilename"].endswith('.gguf'):
+            file = sibling["rfilename"]
+            print(f"- ramalama pull hf://{repo_name}/{file}")
+    print("\n")
+
+
 class Huggingface(Model):
     def __init__(self, model):
         super().__init__(model)
@@ -83,24 +99,7 @@ class Huggingface(Model):
             if self.directory.count("/") == 0:
                 repo_name = self.directory + "/" + self.filename
                 repo_info = get_repo_info(repo_name)
-                if "safetensors" in repo_info and args.runtime == "llama.cpp":
-                    print(
-                        "\n \
-                        llama.cpp does not support running safetensor models, \
-                            please use a/convert to the GGUF format using:\n \
-                                - https://huggingface.co/spaces/ggml-org/gguf-my-repo \n"
-                    )
-                if "gguf" in repo_info:
-                    print(
-                        "There are GGUF files to choose in this repo, \
-                            run one of the following commands to choose one:"
-                    )
-                    for sibling in repo_info["siblings"]:
-                        if sibling["rfilename"].endswith('.gguf'):
-                            file = sibling["rfilename"]
-                            print(f"- ramalama pull hf://{repo_name}/{file}")
-                    print("\n")
-
+                handle_repo_info(repo_name, repo_info, args.runtime)
             return self.url_pull(args, model_path, directory_path)
         except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:
             if self.hf_cli_available:

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -1,7 +1,7 @@
+import json
 import os
 import pathlib
 import urllib.request
-import json
 
 from ramalama.common import available, download_file, exec_cmd, perror, run_cmd, verify_checksum
 from ramalama.model import Model

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -32,17 +32,18 @@ def fetch_checksum_from_api(url):
             return line.split(":", 1)[1].strip()
     raise ValueError("SHA-256 checksum not found in the API response.")
 
+
 def get_repo_info(repo_name):
-        # Docs on API call here: https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
-        repo_info_url = f"https://huggingface.co/api/models/{repo_name}"
-        with urllib.request.urlopen(repo_info_url) as response:
-            if response.getcode() == 200:
-                repo_info = response.read().decode('utf-8')
-                return json.loads(repo_info)
-            else:
-                perror("Huggingface repo information pull failed")
-                raise KeyError(f"Response error code from repo info pull: {response.getcode()}")
-        return None
+    # Docs on API call here: https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
+    repo_info_url = f"https://huggingface.co/api/models/{repo_name}"
+    with urllib.request.urlopen(repo_info_url) as response:
+        if response.getcode() == 200:
+            repo_info = response.read().decode('utf-8')
+            return json.loads(repo_info)
+        else:
+            perror("Huggingface repo information pull failed")
+            raise KeyError(f"Response error code from repo info pull: {response.getcode()}")
+    return None
 
 
 class Huggingface(Model):
@@ -83,9 +84,13 @@ class Huggingface(Model):
                 repo_info = get_repo_info(repo_name)
                 if "safetensors" in repo_info:
                     if args.runtime == "llama.cpp":
-                        print("\nllama.cpp does not support running safetensor models, please use a/convert to the GGUF format using:\n- https://huggingface.co/spaces/ggml-org/gguf-my-repo \n")
+                        print(
+                            "\nllama.cpp does not support running safetensor models, please use a/convert to the GGUF format using:\n- https://huggingface.co/spaces/ggml-org/gguf-my-repo \n"
+                        )
                 if "gguf" in repo_info:
-                    print("There are GGUF files to choose in this repo, run one of the following commands to choose one:")
+                    print(
+                        "There are GGUF files to choose in this repo, run one of the following commands to choose one:"
+                    )
                     for sibling in repo_info["siblings"]:
                         if sibling["rfilename"].endswith('.gguf'):
                             file = sibling["rfilename"]

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -34,7 +34,7 @@ def fetch_checksum_from_api(url):
 
 
 def get_repo_info(repo_name):
-    # Docs on API call here: 
+    # Docs on API call here:
     # https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
     repo_info_url = f"https://huggingface.co/api/models/{repo_name}"
     with urllib.request.urlopen(repo_info_url) as response:


### PR DESCRIPTION
Fixes the size method to allow for directories, and adds the ability to detect and get information on HuggingFace repos when entered in instead of a GGUF file.

Currently just prints out warnings when detecting models ramalama can't run in an ordinary/expected way, can be adjusted to do different things when trying to run or convert from safetensors in the future.

## Summary by Sourcery

Adds functionality to detect and provide information about Hugging Face repositories, including warnings for Safetensor models and multiple GGUF files. Also fixes the get_size method to correctly calculate the size of directories.

Enhancements:
- Improves Hugging Face repository handling by adding checks for Safetensor models and multiple GGUF files, providing users with relevant warnings and instructions.
- Updates the get_size function to accurately calculate the size of directories by recursively summing the sizes of all files within them.