### PR TITLE
detect hf repos, fix get_size for directories

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -449,8 +449,16 @@ def human_readable_size(size):
     return f"{size} PB"
 
 
-def get_size(file):
-    return os.path.getsize(file)
+def get_size(path):
+    if os.path.isdir(path):
+        size = 0
+        for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
+            for file in filenames:
+                filepath = os.path.join(dirpath, file)
+                if not os.path.islink(filepath):
+                    size += os.path.getsize(filepath)
+        return size
+    return os.path.getsize(path)
 
 
 def _list_models(args):

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import urllib.request
@@ -32,6 +33,37 @@ def fetch_checksum_from_api(url):
     raise ValueError("SHA-256 checksum not found in the API response.")
 
 
+def get_repo_info(repo_name):
+    # Docs on API call:
+    # https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
+    repo_info_url = f"https://huggingface.co/api/models/{repo_name}"
+    with urllib.request.urlopen(repo_info_url) as response:
+        if response.getcode() == 200:
+            repo_info = response.read().decode('utf-8')
+            return json.loads(repo_info)
+        else:
+            perror("Huggingface repo information pull failed")
+            raise KeyError(f"Response error code from repo info pull: {response.getcode()}")
+    return None
+
+
+def handle_repo_info(repo_name, repo_info, runtime):
+    if "safetensors" in repo_info and runtime == "llama.cpp":
+        print(
+            "\nllama.cpp does not support running safetensor models, "
+            "please use a/convert to the GGUF format using:\n"
+            f"- https://huggingface.co/models?other=base_model:quantized:{repo_name} \n"
+            "- https://huggingface.co/spaces/ggml-org/gguf-my-repo"
+        )
+    if "gguf" in repo_info:
+        print("There are GGUF files to choose from in this repo, use one of the following commands to run one:\n")
+    for sibling in repo_info["siblings"]:
+        if sibling["rfilename"].endswith('.gguf'):
+            file = sibling["rfilename"]
+            print(f"- ramalama run hf://{repo_name}/{file}")
+    print("\n")
+
+
 class Huggingface(Model):
     def __init__(self, model):
         super().__init__(model)
@@ -64,6 +96,12 @@ class Huggingface(Model):
         os.makedirs(symlink_dir, exist_ok=True)
 
         try:
+            # Check if huggingface repo instead of file
+            if self.directory.count("/") == 0:
+                repo_name = self.directory + "/" + self.filename
+                repo_info = get_repo_info(repo_name)
+                handle_repo_info(repo_name, repo_info, args.runtime)
+
             return self.url_pull(args, model_path, directory_path)
         except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:
             if self.hf_cli_available:

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -57,7 +57,7 @@ def handle_repo_info(repo_name, repo_info, runtime):
         )
     if "gguf" in repo_info:
         print("There are GGUF files to choose from in this repo, use one of the following commands to run one:\n")
-    for sibling in repo_info["siblings"]:
+    for sibling in repo_info.get("siblings", []):
         if sibling["rfilename"].endswith('.gguf'):
             file = sibling["rfilename"]
             print(f"- ramalama run hf://{repo_name}/{file}")


### PR DESCRIPTION
Adds functionality to detect and provide information about Hugging Face repositories, including warnings for Safetensor models and multiple GGUF files. Also fixes the get_size method to correctly calculate the size of directories.

Currently just prints out warnings when detecting models ramalama can't run in an ordinary/expected way, could be adjusted to do different things when trying to run or convert from safetensors in the future.

For the future convert hf to gguf implementation, the llama.cpp script [requires](https://github.com/ggml-org/llama.cpp/blob/master/convert_hf_to_gguf.py) torch and some other dependencies that would increase the container size by ~700 MB, so it might make sense to have a seperate convert container to run the [convert_hf_to_gguf.py](https://github.com/ggml-org/llama.cpp/blob/master/convert_hf_to_gguf.py) script and then [quantize](https://github.com/ggml-org/llama.cpp/blob/master/examples/quantize/README.md) down into the user selected quant.

Still not sure where to store the final/quantized model though, the file model/repo directories make the most sense to me but would probably need to prompt the user that it's under file and not huggingface for the commands.

Example:
```
$ ramalama ls   
NAME MODIFIED SIZE

$ ramalama pull hf://ibm-granite/granite-3.2-2b-instruct

llama.cpp does not support running safetensor models, please use a/convert to the GGUF format using:
- https://huggingface.co/models?other=base_model:quantized:ibm-granite/granite-3.2-2b-instruct 
- https://huggingface.co/spaces/ggml-org/gguf-my-repo


Fetching 13 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 5946.77it/s]

$ ramalama pull hf://lmstudio-community/granite-3.2-2b-instruct-GGUF 
There are GGUF files to choose from in this repo, use one of the following commands to run one:

- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q3_K_L.gguf
- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q4_K_M.gguf
- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q6_K.gguf
- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q8_0.gguf


Fetching 6 files:
...

$ ramalama ls
NAME                                                          MODIFIED      SIZE   
huggingface://lmstudio-community/granite-3.2-2b-instruct-GGUF 8 seconds ago 7.15 GB
huggingface://ibm-granite/granite-3.2-2b-instruct             2 minutes ago 4.72 GB
```

## Summary by Sourcery

Improves Hugging Face repository handling by adding functionality to detect repositories and provide information about their contents, including warnings for Safetensor models and guidance for GGUF files. Fixes the get_size function to correctly calculate the size of directories.

Enhancements:
- Adds functionality to detect Hugging Face repositories and provide information about their contents, including warnings for Safetensor models and guidance for GGUF files.
- Improves error handling for Hugging Face repository information retrieval.
- Adds a warning message when llama.cpp is selected as runtime and the model is in safetensors format, suggesting conversion to GGUF format.
- Prints available GGUF files in a Hugging Face repository and suggests commands to run them.