### PR TITLE
Feat/mlx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,11 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
+
+      - name: install mlx-lm
+        shell: bash
+        run: |
+          uv pip install mlx-lm
           
       - name: install golang
         shell: bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RamaLama then pulls AI Models from model registries, starting a chatbot or REST 
 | :--------------------------------- | :-------------------------: |
 | CPU                                | &check;                     |
 | Apple Silicon GPU (Linux / Asahi)  | &check;                     |
-| Apple Silicon GPU (macOS)          | &check;                     |
+| Apple Silicon GPU (macOS)          | &check; llama.cpp or MLX    |
 | Apple Silicon GPU (podman-machine) | &check;                     |
 | Nvidia GPU (cuda)                  | &check; See note below      |
 | AMD GPU (rocm, vulkan)             | &check;                     |
@@ -86,6 +86,22 @@ See the [Intel hardware table](https://dgpu-docs.intel.com/devices/hardware-tabl
 
 ### Moore Threads GPUs
 On systems with Moore Threads GPUs, see [ramalama-musa](docs/ramalama-musa.7.md) documentation for the correct host system configuration.
+
+### MLX Runtime (macOS only)
+The MLX runtime provides optimized inference for Apple Silicon Macs. MLX requires:
+- macOS operating system
+- Apple Silicon hardware (M1, M2, M3, or later)
+- Usage with `--nocontainer` option (containers are not supported)
+- The `mlx-lm` Python package installed on the host system
+
+To install and run Phi-4 on MLX, use either `uv` or `pip`:
+```bash
+uv pip install mlx-lm
+# or pip:
+pip install mlx-lm
+
+ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
+```
 
 ## Install
 ### Install on Fedora
@@ -1125,6 +1141,7 @@ This project wouldn't be possible without the help of other projects like:
 - [llama.cpp](https://github.com/ggml-org/llama.cpp)
 - [whisper.cpp](https://github.com/ggml-org/whisper.cpp)
 - [vllm](https://github.com/vllm-project/vllm)
+- [mlx-lm](https://github.com/ml-explore/mlx-examples)
 - [podman](https://github.com/containers/podman)
 - [huggingface](https://github.com/huggingface)
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -29,9 +29,12 @@ Modify individual model transports by specifying the `huggingface://`, `oci://`,
 URL support means if a model is on a web site or even on your local system, you can run it directly.
 
 ## REST API ENDPOINTS
-Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
+Under the hood, `ramalama-serve` uses the `llama.cpp` HTTP server by default. When using `--runtime=vllm`, it uses the vLLM server. When using `--runtime=mlx`, it uses the MLX LM server.
 
-For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
+For REST API endpoint documentation, see:
+- llama.cpp: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
+- vLLM: [https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
+- MLX LM: [https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md)
 
 ## OPTIONS
 
@@ -461,6 +464,27 @@ WantedBy=multi-user.target default.target
 ## NVIDIA CUDA Support
 
 See **[ramalama-cuda(7)](ramalama-cuda.7.md)** for setting up the host Linux system for CUDA support.
+
+## MLX Support
+
+The MLX runtime is designed for Apple Silicon Macs and provides optimized performance on these systems. MLX support has the following requirements:
+
+- **Operating System**: macOS only
+- **Hardware**: Apple Silicon (M1, M2, M3, or later)
+- **Container Mode**: MLX requires `--nocontainer` as it cannot run inside containers
+- **Dependencies**: Requires `mlx-lm` package to be installed on the host system
+
+To install MLX dependencies, use either `uv` or `pip`:
+```bash
+uv pip install mlx-lm
+# or pip:
+pip install mlx-lm
+```
+
+Example usage:
+```bash
+ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
+```
 
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -86,8 +86,8 @@
 #
 #pull = "newer"
 
-# Specify the AI runtime to use; valid options are 'llama.cpp' and 'vllm' (default: llama.cpp)
-# Options: llama.cpp, vllm
+# Specify the AI runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx' (default: llama.cpp)
+# Options: llama.cpp, vllm, mlx
 #
 #runtime = "llama.cpp"
 

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -132,8 +132,8 @@ Specify default port for services to listen on
 
 **runtime**="llama.cpp"
 
-Specify the AI runtime to use; valid options are 'llama.cpp' and 'vllm' (default: llama.cpp)
-Options: llama.cpp, vllm
+Specify the AI runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx' (default: llama.cpp)
+Options: llama.cpp, vllm, mlx
 
 **store**="$HOME/.local/share/ramalama"
 

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -69,7 +69,11 @@ class RamaLamaShell(cmd.Cmd):
         self.request_in_process = False
         self.prompt = args.prefix
 
-        self.url = f"{args.url}/chat/completions"
+        # MLX server uses /v1/chat/completions endpoint
+        if getattr(args, "runtime", None) == "mlx":
+            self.url = f"{args.url}/v1/chat/completions"
+        else:
+            self.url = f"{args.url}/chat/completions"
         self.prep_rag_message()
 
     def prep_rag_message(self):

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -216,8 +216,8 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     parser.add_argument(
         "--runtime",
         default=CONFIG.runtime,
-        choices=["llama.cpp", "vllm"],
-        help="specify the runtime to use; valid options are 'llama.cpp' and 'vllm'",
+        choices=["llama.cpp", "vllm", "mlx"],
+        help="specify the runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx'",
     )
     parser.add_argument(
         "--store",
@@ -269,6 +269,12 @@ def post_parse_setup(args):
             args.MODEL = resolved_model
     if hasattr(args, "runtime_args"):
         args.runtime_args = shlex.split(args.runtime_args)
+
+    # MLX runtime automatically requires --nocontainer
+    if getattr(args, "runtime", None) == "mlx":
+        if getattr(args, "container", None) is True:
+            logger.info("MLX runtime automatically uses --nocontainer mode")
+        args.container = False
 
     configure_logger("DEBUG" if args.debug else "WARNING")
 

--- a/test/system/080-mlx.bats
+++ b/test/system/080-mlx.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+
+load helpers
+
+MODEL=hf://mlx-community/SmolLM-135M-4bit
+
+function skip_if_not_apple_silicon() {
+    if ! is_apple_silicon; then
+        skip "MLX runtime requires macOS with Apple Silicon"
+    fi
+}
+
+function skip_if_no_mlx() {
+    if ! python3 -c "import mlx_lm" 2>/dev/null; then
+        skip "MLX runtime requires mlx-lm package to be installed"
+    fi
+}
+
+@test "ramalama --runtime=mlx help shows MLX option" {
+    run_ramalama --help
+    is "$output" ".*mlx.*" "MLX should be listed as runtime option"
+}
+
+@test "ramalama --runtime=mlx info shows MLX runtime" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx info
+    is "$output" ".*Runtime.*mlx.*" "info should show MLX runtime"
+}
+
+@test "ramalama --runtime=mlx automatically enables --nocontainer" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # MLX should automatically set --nocontainer even when not specified
+    run_ramalama --runtime=mlx --dryrun run ${MODEL}
+    # Should succeed without error about container requirements
+    is "$status" "0" "MLX should auto-enable --nocontainer"
+    # Should not contain container runtime commands
+    assert "$output" !~ "podman\|docker" "should not use container runtime"
+}
+
+@test "ramalama --runtime=mlx --container shows warning but works" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # When user explicitly specifies --container with MLX, should warn but auto-switch to --nocontainer
+    run_ramalama --runtime=mlx --container --dryrun run ${MODEL}
+    is "$status" "0" "should work despite --container flag"
+    assert "$output" !~ "podman\|docker" "should not use container runtime even with --container flag"
+}
+
+@test "ramalama --runtime=mlx --dryrun run shows direct generation" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun run ${MODEL}
+    is "$status" "0" "MLX run should work"
+    # Should use python -m mlx_lm chat
+    is "$output" ".*python.*-m.*mlx_lm.*chat.*" "should use MLX chat command"
+    assert "$output" !~ "server\|serve" "should not use server mode"
+}
+
+@test "ramalama --runtime=mlx --dryrun run with prompt shows command args" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    prompt="Hello, how are you?"
+    run_ramalama --runtime=mlx --dryrun run ${MODEL} "$prompt"
+    is "$status" "0" "MLX run with prompt should work"
+    is "$output" ".*python.*-m.*mlx_lm.*generate.*--prompt.*Hello, how are you\?.*" "should use MLX generate with --prompt"
+    # mlx_lm.generate passes prompt via argument
+}
+
+@test "ramalama --runtime=mlx --dryrun run with temperature" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun run --temp 0.5 ${MODEL} "test"
+    is "$status" "0" "MLX run with temperature should work"
+    is "$output" ".*--temp.*0.5.*" "should include temperature setting"
+}
+
+@test "ramalama --runtime=mlx --dryrun run with max tokens" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun run --ctx-size 1024 ${MODEL} "test"
+    is "$status" "0" "MLX run with ctx-size should work"
+    is "$output" ".*--max-tokens.*1024.*" "should include max tokens setting"
+}
+
+@test "ramalama --runtime=mlx --dryrun serve shows MLX server command" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun serve ${MODEL}
+    is "$status" "0" "MLX serve should work"
+    # Should use python -m mlx_lm.server
+    is "$output" ".*python.*-m.*mlx_lm server.*" "should use MLX server command"
+    is "$output" ".*--port.*8080.*" "should include default port"
+}
+
+@test "ramalama --runtime=mlx --dryrun serve with custom port" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun serve --port 9090 ${MODEL}
+    is "$status" "0" "MLX serve with custom port should work"
+    is "$output" ".*--port.*9090.*" "should include custom port"
+}
+
+@test "ramalama --runtime=mlx --dryrun serve with host" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun serve --host 127.0.0.1 ${MODEL}
+    is "$status" "0" "MLX serve with custom host should work"
+    is "$output" ".*--host.*127.0.0.1.*" "should include custom host"
+}
+
+@test "ramalama --runtime=mlx run fails on non-Apple Silicon" {
+    if is_apple_silicon; then
+        skip "This test only runs on non-Apple Silicon systems"
+    fi
+    
+    run_ramalama 22 --runtime=mlx run ${MODEL}
+    is "$output" ".*MLX.*Apple Silicon.*" "should show Apple Silicon requirement error"
+}
+
+@test "ramalama --runtime=mlx serve fails on non-Apple Silicon" {
+    if is_apple_silicon; then
+        skip "This test only runs on non-Apple Silicon systems"
+    fi
+    
+    run_ramalama 22 --runtime=mlx serve ${MODEL}
+    is "$output" ".*MLX.*Apple Silicon.*" "should show Apple Silicon requirement error"
+}
+
+@test "ramalama --runtime=mlx works with ollama model format" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    model="ollama://smollm:135m"
+    run_ramalama --runtime=mlx --dryrun run "$model"
+    is "$status" "0" "MLX should work with ollama model format"
+    is "$output" ".*python.*-m.*mlx_lm.*chat.*" "should use MLX chat command"
+}
+
+@test "ramalama --runtime=mlx works with huggingface model format" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    model="huggingface://microsoft/DialoGPT-small"
+    run_ramalama --runtime=mlx --dryrun run "$model"
+    is "$status" "0" "MLX should work with huggingface model format"
+    is "$output" ".*python.*-m.*mlx_lm.*chat.*" "should use MLX chat command"
+}
+
+@test "ramalama --runtime=mlx rejects --name option" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # --name requires container mode, which MLX doesn't support
+    run_ramalama 1 --runtime=mlx run --name test ${MODEL}
+    is "$output" ".*--nocontainer.*--name.*conflict.*" "should show conflict error"
+}
+
+@test "ramalama --runtime=mlx rejects --privileged option" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # --privileged requires container mode, which MLX doesn't support
+    run_ramalama 1 --runtime=mlx run --privileged ${MODEL}
+    is "$output" ".*--nocontainer.*--privileged.*conflict.*" "should show conflict error"
+}
+
+# vim: filetype=sh 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -258,6 +258,16 @@ function skip_if_darwin() {
     fi
 }
 
+function is_apple_silicon() {
+    # Check if we're on macOS and have Apple Silicon (arm64)
+    if is_darwin; then
+        arch=$(uname -m)
+        [[ "$arch" == "arm64" ]]
+    else
+        return 1
+    fi
+}
+
 function skip_if_no_hf-cli(){
     if ! command -v huggingface-cli 2>&1 >/dev/null
     then


### PR DESCRIPTION
## Summary by Sourcery

Enable a new ‘mlx’ runtime option that integrates the `mlx_lm` Python package for optimized Apple Silicon inference, wiring it into the CLI, model execution paths (run, serve, bench), enforcing platform constraints, updating documentation, and covering it with unit and system tests.

New Features:
- Add MLX runtime support for interactive chat, one-shot generation, serving, and benchmarking via the `mlx_lm` CLI

Enhancements:
- Enforce MLX runtime only on Apple Silicon macOS with automatic `--nocontainer` mode and validation
- Refactor model store type hint to `ModelStore | None` and add helper methods for building MLX subprocess arguments

CI:
- Install `mlx-lm` package in CI workflows

Documentation:
- Document MLX runtime requirements and usage in README, man pages, and configuration files

Tests:
- Add unit tests for MLX runtime argument building, validation, and behavior
- Add system BATS tests covering MLX CLI commands and runtime constraints