### PR TITLE
feat: hf-cache is back

### DIFF
--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -239,7 +239,7 @@ class Config(LayeredMixin, BaseConfig):
         """
         is_podman = self.engine is not None and os.path.basename(self.engine) == "podman"
         if is_podman and sys.platform == "darwin":
-            run_with_podman_engine = apple_vm(self.engine, self)
+            run_with_podman_engine = apple_vm("podman", self)
             if not run_with_podman_engine and not self.is_set("engine"):
                 self.engine = "docker" if available("docker") else None
 

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -134,7 +134,7 @@ class HFStyleRepository(ABC):
             url=f"{self.blob_url}/{self.model_filename}",
             header=self.headers,
             hash=self.model_hash,
-            type=SnapshotFileType.GGUFModel,
+            type=getattr(self, "model_type", SnapshotFileType.GGUFModel),
             name=self.model_filename,
             should_show_progress=True,
             should_verify_checksum=True,
@@ -278,12 +278,23 @@ class HFStyleRepoModel(Transport, ABC):
             repo = self.create_repository(name, organization, tag)
             snapshot_hash = repo.model_hash
             files = repo.get_file_list(cached_files)
+            
+            # Check external caches for files before downloading
+            for file in files:
+                blob_path = self.model_store.get_blob_file_path(file.hash)
+                if not os.path.exists(blob_path):
+                    if self.in_existing_cache(args, blob_path, file.hash):
+                        logger.debug(f"Found {file.name} in external cache")
+
             self.model_store.new_snapshot(tag, snapshot_hash, files, verify=getattr(args, "verify", True))
 
         except EndianMismatchError:
             # No use pulling again
             raise
         except Exception as e:
+            if isinstance(e, urllib.error.HTTPError) and e.code == 404:
+                 raise KeyError(f"Model not found: {str(e)}")
+
             if not available(self.get_cli_command()):
                 perror(f"URL pull failed and {self.get_cli_command()} not available")
                 raise KeyError(f"Failed to pull model: {str(e)}")

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -278,7 +278,7 @@ class HFStyleRepoModel(Transport, ABC):
             repo = self.create_repository(name, organization, tag)
             snapshot_hash = repo.model_hash
             files = repo.get_file_list(cached_files)
-            
+
             # Check external caches for files before downloading
             for file in files:
                 blob_path = self.model_store.get_blob_file_path(file.hash)
@@ -293,7 +293,7 @@ class HFStyleRepoModel(Transport, ABC):
             raise
         except Exception as e:
             if isinstance(e, urllib.error.HTTPError) and e.code == 404:
-                 raise KeyError(f"Model not found: {str(e)}")
+                raise KeyError(f"Model not found: {str(e)}")
 
             if not available(self.get_cli_command()):
                 perror(f"URL pull failed and {self.get_cli_command()} not available")

--- a/ramalama/model_store/global_store.py
+++ b/ramalama/model_store/global_store.py
@@ -6,10 +6,9 @@ from typing import Dict, List
 from ramalama import oci_tools
 from ramalama.arg_types import EngineArgs
 from ramalama.model_store.constants import DIRECTORY_NAME_BLOBS, DIRECTORY_NAME_REFS, DIRECTORY_NAME_SNAPSHOTS
+from ramalama.model_store.hf_cache import list_hf_cache_models
 from ramalama.model_store.reffile import RefJSONFile, migrate_reffile_to_refjsonfile
 
-
-from ramalama.model_store.hf_cache import list_hf_cache_models
 
 @dataclass
 class ModelFile:
@@ -90,13 +89,11 @@ class GlobalModelStore:
         for name, files in hf_models.items():
             # Differentiate native models vs hf cache by suffix
             # Also check if native model exists (with :latest/main tag usually)
-            # We don't want to hide HF cache models just because a native one exists, 
+            # We don't want to hide HF cache models just because a native one exists,
             # as they might be different versions/files.
             display_name = f"{name} (hf-cache)"
-            
-            models[display_name] = [
-                ModelFile(f.name, f.modified, f.size, f.is_partial) for f in files
-            ]
+
+            models[display_name] = [ModelFile(f.name, f.modified, f.size, f.is_partial) for f in files]
 
         return models
 

--- a/ramalama/model_store/global_store.py
+++ b/ramalama/model_store/global_store.py
@@ -9,6 +9,8 @@ from ramalama.model_store.constants import DIRECTORY_NAME_BLOBS, DIRECTORY_NAME_
 from ramalama.model_store.reffile import RefJSONFile, migrate_reffile_to_refjsonfile
 
 
+from ramalama.model_store.hf_cache import list_hf_cache_models
+
 @dataclass
 class ModelFile:
     name: str
@@ -82,6 +84,19 @@ class GlobalModelStore:
                 # oci_tools.list_models provides modified as timestamp string, convert it to unix timestamp
                 modified_unix = datetime.fromisoformat(modified).timestamp()
                 models[name] = [ModelFile(name, modified_unix, size, is_partial=False)]
+
+        # List models from HuggingFace cache
+        hf_models = list_hf_cache_models()
+        for name, files in hf_models.items():
+            # Differentiate native models vs hf cache by suffix
+            # Also check if native model exists (with :latest/main tag usually)
+            # We don't want to hide HF cache models just because a native one exists, 
+            # as they might be different versions/files.
+            display_name = f"{name} (hf-cache)"
+            
+            models[display_name] = [
+                ModelFile(f.name, f.modified, f.size, f.is_partial) for f in files
+            ]
 
         return models
 

--- a/ramalama/model_store/hf_cache.py
+++ b/ramalama/model_store/hf_cache.py
@@ -93,7 +93,7 @@ class CachedModelFile:
 
 def list_hf_cache_models() -> dict[str, List[CachedModelFile]]:
     """List models present in the HuggingFace cache directories"""
-    models = {}
+    models: dict[str, List[CachedModelFile]] = {}
 
     for cache_dir in get_hf_cache_dirs():
         if not os.path.exists(cache_dir):

--- a/ramalama/model_store/hf_cache.py
+++ b/ramalama/model_store/hf_cache.py
@@ -1,0 +1,132 @@
+import os
+import pathlib
+from typing import List, Optional
+
+# Constants for environment variables and paths
+ENV_HF_TOKEN = "HF_TOKEN"
+ENV_HF_HOME = "HF_HOME"
+ENV_HF_HUB_CACHE = "HUGGINGFACE_HUB_CACHE"
+DEFAULT_CACHE_HOME = os.path.expanduser("~/.cache/huggingface")
+
+
+def _read_token_from_path(path: str) -> Optional[str]:
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def huggingface_token() -> Optional[str]:
+    """Return cached Hugging Face token if it exists otherwise None"""
+    if token := os.environ.get(ENV_HF_TOKEN):
+        return token
+
+    possible_paths = []
+    if hf_home := os.environ.get(ENV_HF_HOME):
+        possible_paths.append(os.path.join(hf_home, "token"))
+    possible_paths.append(os.path.join(DEFAULT_CACHE_HOME, "token"))
+
+    for path in possible_paths:
+        if os.path.exists(path):
+            if token := _read_token_from_path(path):
+                return token
+    return None
+
+
+def get_hf_cache_dirs() -> List[str]:
+    """Return a list of potential Hugging Face cache directories"""
+    cache_dirs = []
+    if hub_cache := os.environ.get(ENV_HF_HUB_CACHE):
+        cache_dirs.append(hub_cache)
+    if hf_home := os.environ.get(ENV_HF_HOME):
+        cache_dirs.append(os.path.join(hf_home, "hub"))
+    cache_dirs.append(os.path.join(DEFAULT_CACHE_HOME, "hub"))
+    return cache_dirs
+
+
+def _get_snapshot_path(cache_dir: str, namespace: str, repo: str) -> Optional[str]:
+    cache_path = os.path.join(cache_dir, f'models--{namespace}--{repo}')
+    ref_path = os.path.join(cache_path, 'refs', 'main')
+    
+    if not os.path.exists(ref_path):
+        return None
+        
+    try:
+        with open(ref_path, 'r') as f:
+            snapshot = f.read().strip()
+        return os.path.join(cache_path, 'snapshots', snapshot)
+    except OSError:
+        return None
+
+
+def find_file_in_cache(directory: str, filename: str, sha256_checksum: str) -> Optional[str]:
+    """Find a file in the Hugging Face cache matching the checksum."""
+    namespace, repo = os.path.split(str(directory))
+    expected_hash = sha256_checksum.removeprefix("sha256:")
+
+    for cache_dir in get_hf_cache_dirs():
+        snapshot_path = _get_snapshot_path(cache_dir, namespace, repo)
+        if not snapshot_path:
+            continue
+
+        file_path = os.path.join(snapshot_path, filename)
+        blob_path = pathlib.Path(file_path).resolve()
+        
+        if not blob_path.exists():
+            continue
+
+        # Verify it points to the correct blob in the cache
+        if blob_path.name == expected_hash:
+            return str(blob_path)
+            
+    return None
+
+
+class CachedModelFile:
+    def __init__(self, name: str, modified: float, size: int):
+        self.name = name
+        self.modified = modified
+        self.size = size
+        self.is_partial = False
+
+
+def list_hf_cache_models() -> dict[str, List[CachedModelFile]]:
+    """List models present in the HuggingFace cache directories"""
+    models = {}
+
+    for cache_dir in get_hf_cache_dirs():
+        if not os.path.exists(cache_dir):
+            continue
+
+        try:
+            entries = [e for e in os.listdir(cache_dir) if e.startswith("models--")]
+        except OSError:
+            continue
+
+        for entry in entries:
+            parts = entry.split("--")
+            if len(parts) < 3:
+                continue
+            
+            namespace, repo = parts[1], "--".join(parts[2:])
+            snapshot_path = _get_snapshot_path(cache_dir, namespace, repo)
+            
+            if not snapshot_path:
+                continue
+
+            model_files = []
+            for root, _, files in os.walk(snapshot_path):
+                for file in files:
+                    if file.endswith((".gguf", ".safetensors")):
+                        try:
+                            stat = os.stat(os.path.join(root, file))
+                            model_files.append(CachedModelFile(file, stat.st_mtime, stat.st_size))
+                        except OSError:
+                            pass
+            
+            if model_files:
+                key = f"hf://{namespace}/{repo}"
+                models.setdefault(key, []).extend(model_files)
+                    
+    return models

--- a/ramalama/model_store/hf_cache.py
+++ b/ramalama/model_store/hf_cache.py
@@ -48,10 +48,10 @@ def get_hf_cache_dirs() -> List[str]:
 def _get_snapshot_path(cache_dir: str, namespace: str, repo: str) -> Optional[str]:
     cache_path = os.path.join(cache_dir, f'models--{namespace}--{repo}')
     ref_path = os.path.join(cache_path, 'refs', 'main')
-    
+
     if not os.path.exists(ref_path):
         return None
-        
+
     try:
         with open(ref_path, 'r') as f:
             snapshot = f.read().strip()
@@ -72,14 +72,14 @@ def find_file_in_cache(directory: str, filename: str, sha256_checksum: str) -> O
 
         file_path = os.path.join(snapshot_path, filename)
         blob_path = pathlib.Path(file_path).resolve()
-        
+
         if not blob_path.exists():
             continue
 
         # Verify it points to the correct blob in the cache
         if blob_path.name == expected_hash:
             return str(blob_path)
-            
+
     return None
 
 
@@ -108,10 +108,10 @@ def list_hf_cache_models() -> dict[str, List[CachedModelFile]]:
             parts = entry.split("--")
             if len(parts) < 3:
                 continue
-            
+
             namespace, repo = parts[1], "--".join(parts[2:])
             snapshot_path = _get_snapshot_path(cache_dir, namespace, repo)
-            
+
             if not snapshot_path:
                 continue
 
@@ -124,9 +124,9 @@ def list_hf_cache_models() -> dict[str, List[CachedModelFile]]:
                             model_files.append(CachedModelFile(file, stat.st_mtime, stat.st_size))
                         except OSError:
                             pass
-            
+
             if model_files:
                 key = f"hf://{namespace}/{repo}"
                 models.setdefault(key, []).extend(model_files)
-                    
+
     return models

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -1,6 +1,5 @@
 import json
 import os
-import pathlib
 import urllib.request
 
 from ramalama.common import available, perror, run_cmd
@@ -30,7 +29,6 @@ sudo dnf install python3-huggingface-hub
 def is_hf_cli_available():
     """Check if huggingface-cli is available on the system."""
     return available("hf")
-
 
 
 def extract_huggingface_checksum(data):
@@ -92,9 +90,9 @@ class HuggingfaceRepository(HFStyleRepository):
         except KeyError:
             # Fallback to safetensors
             if 'safetensors' in self.manifest:
-                 self.model_filename = self.manifest['safetensors']['rfilename']
-                 self.model_hash = self.manifest['safetensors']['blobId']
-                 self.model_type = SnapshotFileType.SafetensorModel
+                self.model_filename = self.manifest['safetensors']['rfilename']
+                self.model_hash = self.manifest['safetensors']['blobId']
+                self.model_type = SnapshotFileType.SafetensorModel
             else:
                 perror("Repository manifest missing ggufFile or safetensors data")
                 raise
@@ -114,9 +112,9 @@ class HuggingfaceRepositoryModel(HuggingfaceRepository):
         if self.name.endswith(".gguf"):
             self.model_type = SnapshotFileType.GGUFModel
         elif self.name.endswith(".safetensors"):
-             self.model_type = SnapshotFileType.SafetensorModel
+            self.model_type = SnapshotFileType.SafetensorModel
         else:
-             self.model_type = SnapshotFileType.Other
+            self.model_type = SnapshotFileType.Other
 
         token = huggingface_token()
         if token is not None:

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -11,6 +11,7 @@ from ramalama.hf_style_repo_base import (
     fetch_checksum_from_api_base,
 )
 from ramalama.logger import logger
+from ramalama.model_store.hf_cache import find_file_in_cache, huggingface_token
 from ramalama.model_store.snapshot_file import SnapshotFileType
 from ramalama.path_utils import create_file_link
 
@@ -30,16 +31,6 @@ def is_hf_cli_available():
     """Check if huggingface-cli is available on the system."""
     return available("hf")
 
-
-def huggingface_token():
-    """Return cached Hugging Face token if it exists otherwise None"""
-    token_path = os.path.expanduser(os.path.join("~", ".cache", "huggingface", "token"))
-    if os.path.exists(token_path):
-        try:
-            with open(token_path) as tokenfile:
-                return tokenfile.read().strip()
-        except OSError:
-            pass
 
 
 def extract_huggingface_checksum(data):
@@ -97,9 +88,16 @@ class HuggingfaceRepository(HFStyleRepository):
         try:
             self.model_filename = self.manifest['ggufFile']['rfilename']
             self.model_hash = self.manifest['ggufFile']['blobId']
+            self.model_type = SnapshotFileType.GGUFModel
         except KeyError:
-            perror("Repository manifest missing ggufFile data")
-            raise
+            # Fallback to safetensors
+            if 'safetensors' in self.manifest:
+                 self.model_filename = self.manifest['safetensors']['rfilename']
+                 self.model_hash = self.manifest['safetensors']['blobId']
+                 self.model_type = SnapshotFileType.SafetensorModel
+            else:
+                perror("Repository manifest missing ggufFile or safetensors data")
+                raise
         self.mmproj_filename = self.manifest.get('mmprojFile', {}).get('rfilename', None)
         self.mmproj_hash = self.manifest.get('mmprojFile', {}).get('blobId', None)
         token = huggingface_token()
@@ -113,6 +111,13 @@ class HuggingfaceRepositoryModel(HuggingfaceRepository):
         self.blob_url = f"{HuggingfaceRepository.REGISTRY_URL}/{self.organization}/resolve/main"
         self.model_hash = f"sha256:{fetch_checksum_from_api(self.organization, self.name)}"
         self.model_filename = self.name
+        if self.name.endswith(".gguf"):
+            self.model_type = SnapshotFileType.GGUFModel
+        elif self.name.endswith(".safetensors"):
+             self.model_type = SnapshotFileType.SafetensorModel
+        else:
+             self.model_type = SnapshotFileType.Other
+
         token = huggingface_token()
         if token is not None:
             self.headers['Authorization'] = f"Bearer {token}"
@@ -196,43 +201,16 @@ class Huggingface(HFStyleRepoModel):
                 model_tag = model_tag.upper()
         return model_name, model_tag, model_organization
 
-    def _fetch_snapshot_path(self, cache_dir, namespace, repo):
-        cache_path = os.path.join(cache_dir, f'models--{namespace}--{repo}')
-        main_ref_path = os.path.join(cache_path, 'refs', 'main')
-        if not (os.path.exists(cache_path) and os.path.exists(main_ref_path)):
-            return None, None
-        with open(main_ref_path, 'r') as file:
-            snapshot = file.read().strip()
-        snapshot_path = os.path.join(cache_path, 'snapshots', snapshot)
-        return snapshot_path, cache_path
-
     def in_existing_cache(self, args, target_path, sha256_checksum):
         if not self.hf_cli_available:
             return False
 
-        default_hf_caches = [os.path.join(os.environ['HOME'], '.cache/huggingface/hub')]
-        namespace, repo = os.path.split(str(self.directory))
-
-        for cache_dir in default_hf_caches:
-            snapshot_path, cache_path = self._fetch_snapshot_path(cache_dir, namespace, repo)
-            if not snapshot_path or not cache_path or not os.path.exists(snapshot_path):
-                continue
-
-            file_path = os.path.join(snapshot_path, self.filename)
-            if not os.path.exists(file_path):
-                continue
-
-            blob_path = pathlib.Path(file_path).resolve()
-            if not os.path.exists(blob_path):
-                continue
-
-            blob_file = os.path.relpath(blob_path, start=os.path.join(cache_path, 'blobs'))
-            if str(blob_file) != str(sha256_checksum):
-                continue
-
+        blob_path = find_file_in_cache(self.directory, self.filename, sha256_checksum)
+        if blob_path:
             # Use cross-platform file linking (hardlink/symlink/copy)
-            create_file_link(str(blob_path), target_path)
+            create_file_link(blob_path, target_path)
             return True
+
         return False
 
     def push(self, _, args):


### PR DESCRIPTION
## Summary by Sourcery

Reintroduce Hugging Face local cache support by adding a dedicated hf_cache module for token handling, cache discovery, and model listing; integrate it into transports and the global model store; and enhance metadata parsing with model type detection and safetensors fallback to streamline caching and avoid redundant downloads.

New Features:
- Add hf_cache module to read tokens, locate files in Hugging Face local cache, and list cached models
- Extend global model store to include and display models found in the Hugging Face cache
- Introduce detection of model file types (GGUF, safetensors, other) with fallback logic in fetch_metadata
- Check and link files from external Hugging Face cache during pull to avoid unnecessary downloads

Enhancements:
- Remove legacy CLI-based cache lookup and consolidate into find_file_in_cache and create_file_link
- Unify token retrieval logic by moving huggingface_token into hf_cache and supporting environment variable overrides